### PR TITLE
Remove the datasource default value for the prometheus target

### DIFF
--- a/specs/7.0/targets/Prometheus.yml
+++ b/specs/7.0/targets/Prometheus.yml
@@ -5,7 +5,6 @@ Prometheus:
   properties:
     datasource:
       type: string
-      default: default
     expr:
       type: string
     format:


### PR DESCRIPTION
This is inspired by #9, but instead of removing the datasource parameter
completely, it only removes the default value.
This is a good compromise, since if you're using the mixed datasource,
you're probably going to want to customize the datasource on the target
level anyway, so a default value doesn't make much sense.